### PR TITLE
Updated Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,7 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Goland IDE file
+.idea
+
 bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
 WORKDIR /go/src/github.com/openshift/machine-api-provider-powervs
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,13 @@ REPO_PATH   ?= github.com/openshift/machine-api-provider-powervs
 LD_FLAGS    ?= -X $(REPO_PATH)/pkg/version.Raw=$(VERSION) -extldflags "-static"
 MUTABLE_TAG ?= latest
 IMAGE        = origin-powervs-machine-controllers
-
-.PHONY: all
-all: generate build images check
+BUILD_IMAGE ?= registry.ci.openshift.org/openshift/release:golang-1.17
 
 NO_DOCKER ?= 0
+
+# race tests need CGO_ENABLED, everything else should have it disabled
+CGO_ENABLED = 0
+unit : CGO_ENABLED = 1
 
 ifeq ($(shell command -v podman > /dev/null 2>&1 ; echo $$? ), 0)
 	ENGINE=podman
@@ -50,12 +52,15 @@ ifeq ($(USE_DOCKER), 1)
 endif
 
 ifeq ($(NO_DOCKER), 1)
-  DOCKER_CMD =
+  DOCKER_CMD = CGO_ENABLED=$(CGO_ENABLED)
   IMAGE_BUILD_CMD = imagebuilder
 else
-  DOCKER_CMD := $(ENGINE) run --rm -v "$(PWD)":/go/src/github.com/openshift/machine-api-provider-powervs:Z -w /go/src/github.com/openshift/machine-api-provider-powervs openshift/origin-release:golang-1.16
+  DOCKER_CMD := $(ENGINE) run --rm -e CGO_ENABLED=$(CGO_ENABLED) -v "$(PWD)":/go/src/github.com/openshift/machine-api-provider-powervs:Z -w /go/src/github.com/openshift/machine-api-provider-powervs $(BUILD_IMAGE)
   IMAGE_BUILD_CMD = $(ENGINE) build
 endif
+
+.PHONY: all
+all: generate build images check
 
 .PHONY: vendor
 vendor:
@@ -79,7 +84,7 @@ bin:
 
 .PHONY: build
 build: ## build binaries
-	$(DOCKER_CMD) CGO_ENABLED=0 go build $(GOGCFLAGS) -o "bin/machine-controller-manager" \
+	$(DOCKER_CMD) go build $(GOGCFLAGS) -o "bin/machine-controller-manager" \
                -ldflags "$(LD_FLAGS)" "$(REPO_PATH)/cmd/manager"
 
 .PHONY: images


### PR DESCRIPTION
This PR contains following changes
1. Updated docker image used to build targets to go 1.17
2. Update Docker file to fix make images failure
3. Added .idea directory generated by GoLand IDE to gitignor file