### PR TITLE
Set zone, region labels to machines

### DIFF
--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -243,6 +243,20 @@ func (r *Reconciler) setMachineCloudProviderSpecifics(instance *models.PVMInstan
 		r.machine.Annotations[machinecontroller.MachineInstanceStateAnnotationName] = *instance.Status
 	}
 
+	region := r.powerVSClient.GetRegion()
+	if region != "" {
+		r.machine.Labels[machinecontroller.MachineRegionLabelName] = region
+	}
+
+	zone := r.powerVSClient.GetZone()
+	if zone != "" {
+		r.machine.Labels[machinecontroller.MachineAZLabelName] = zone
+	}
+
+	if instance.SysType != "" {
+		r.machine.Labels[machinecontroller.MachineInstanceTypeLabelName] = instance.SysType
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Currently the zone, region and instance type labels are not set to the machines so the information is not displayed when we are querying for machine resources in cluster

```
karthikkn@Karthiks-MacBook-Pro cluster-api % oc get machine -A
NAMESPACE               NAME                                     PHASE     TYPE   REGION   ZONE   AGE
openshift-machine-api   powervs-actuator-testing-machine-dwbnj   Running                          30m
openshift-machine-api   rdr-kabhat-mrl5n-master-0                Running                          5d5h
openshift-machine-api   rdr-kabhat-mrl5n-master-1                Running                          5d5h
openshift-machine-api   rdr-kabhat-mrl5n-master-2                Running                          5d5h
openshift-machine-api   rdr-kabhat-mrl5n-worker-dbggh            Running                          5d4h
openshift-machine-api   rdr-kabhat-mrl5n-worker-dqtcz            Running                          5d4h
openshift-machine-api   rdr-kabhat-mrl5n-worker-rcllh            Running                          5d4h
```

After this change the machine resource is displayed as below

```
karthikkn@Karthiks-MacBook-Pro nodelink-controller % oc get machine -A
NAMESPACE               NAME                            PHASE     TYPE   REGION   ZONE    AGE
openshift-machine-api   rdr-kabhat-mrl5n-master-0       Running   s922   lon      lon04   5d6h
openshift-machine-api   rdr-kabhat-mrl5n-master-1       Running   s922   lon      lon04   5d6h
openshift-machine-api   rdr-kabhat-mrl5n-master-2       Running   s922   lon      lon04   5d6h
openshift-machine-api   rdr-kabhat-mrl5n-worker-dbggh   Running   s922   lon      lon04   5d6h
openshift-machine-api   rdr-kabhat-mrl5n-worker-dqtcz   Running   s922   lon      lon04   5d6h
openshift-machine-api   rdr-kabhat-mrl5n-worker-rcllh   Running   s922   lon      lon04   5d6h
```