### PR TITLE
Fixed Provider ID format

### DIFF
--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -153,7 +153,7 @@ func getNetworkID(network powervsproviderv1.PowerVSResourceReference, client pow
 
 func getServiceInstanceID(serviceInstance powervsproviderv1.PowerVSResourceReference, client powervsclient.Client) (*string, error) {
 	if serviceInstance.ID != nil {
-		klog.Infof("Found the service %v", serviceInstance)
+		klog.Infof("Found the service with ID %s", *serviceInstance.ID)
 		return serviceInstance.ID, nil
 	} else if serviceInstance.Name != nil {
 		serviceInstances, err := client.GetCloudServiceInstanceByName(*serviceInstance.Name)

--- a/pkg/actuators/machine/reconciler_test.go
+++ b/pkg/actuators/machine/reconciler_test.go
@@ -200,15 +200,20 @@ func TestCreate(t *testing.T) {
 		// create fake resources
 		t.Logf("testCase: %v", tc.testcase)
 
-		encodedProviderConfig, err := v1alpha1.RawExtensionFromProviderSpec(tc.providerConfig)
-		if err != nil {
-			t.Fatalf("Unexpected error")
-		}
 		machine, err := stubMachine()
 		if err != nil {
 			t.Fatal(err)
 		}
+		encodedProviderConfig, err := v1alpha1.RawExtensionFromProviderSpec(tc.providerConfig)
+		if err != nil {
+			t.Fatalf("Unexpected error")
+		}
+		providerStatus, err := v1alpha1.RawExtensionFromProviderStatus(stubProviderStatus(powerVSProviderID))
+		if err != nil {
+			t.Fatalf("Failed to set providerStatus")
+		}
 		machine.Spec.ProviderSpec = machinev1beta1.ProviderSpec{Value: encodedProviderConfig}
+		machine.Status.ProviderStatus = providerStatus
 
 		fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, machine, tc.powerVSCredentialsSecret, tc.userDataSecret)
 

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -30,6 +30,8 @@ const (
 	instanceGUID          = "testGUID"
 )
 
+var powerVSProviderID = fmt.Sprintf("powervs://test-region/test-zone/test-service-instanceid/test-instanceid")
+
 func stubUserDataSecret(name string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -95,6 +97,12 @@ func stubProviderConfig(name string) *v1alpha1.PowerVSMachineProviderConfig {
 		ServiceInstance: v1alpha1.PowerVSResourceReference{
 			ID: core.StringPtr(instanceID),
 		},
+	}
+}
+
+func stubProviderStatus(serviceInstanceID string) *v1alpha1.PowerVSMachineProviderStatus {
+	return &v1alpha1.PowerVSMachineProviderStatus{
+		ServiceInstanceID: core.StringPtr(serviceInstanceID),
 	}
 }
 

--- a/pkg/apis/powervsprovider/v1alpha1/powervsmachineproviderstatus_types.go
+++ b/pkg/apis/powervsprovider/v1alpha1/powervsmachineproviderstatus_types.go
@@ -31,6 +31,10 @@ type PowerVSMachineProviderStatus struct {
 	// +optional
 	InstanceID *string `json:"instanceId,omitempty"`
 
+	// ServiceInstanceID is the reference to the Power VS ServiceInstance on which the machine instance will be created.
+	// +optional
+	ServiceInstanceID *string `json:"serviceInstanceID,omitempty"`
+
 	// InstanceState is the state of the PowerVS instance for this machine
 	// +optional
 	InstanceState *string `json:"instanceState,omitempty"`

--- a/pkg/apis/powervsprovider/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/powervsprovider/v1alpha1/zz_generated.deepcopy.go
@@ -122,6 +122,11 @@ func (in *PowerVSMachineProviderStatus) DeepCopyInto(out *PowerVSMachineProvider
 		*out = new(string)
 		**out = **in
 	}
+	if in.ServiceInstanceID != nil {
+		in, out := &in.ServiceInstanceID, &out.ServiceInstanceID
+		*out = new(string)
+		**out = **in
+	}
 	if in.InstanceState != nil {
 		in, out := &in.InstanceState, &out.InstanceState
 		*out = new(string)


### PR DESCRIPTION
This PR contains following changes
1. To fix the ProviderID format when ServiceInstance.ID or ServiceInstance.Name is passed in spec 
2. Storing the ServiceInstanceID in machine status so that it can be easily fetched against making a query to Power Cloud
3. Storing the ServiceInstanceID in status field so that user will not edit

Fixes: [15](https://github.com/openshift/machine-api-provider-powervs/issues/15)