### PR TITLE
Bug 2100033: Fetch VM IP from DHCP server to set NodeInternalIP

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,6 +46,7 @@ type Actuator struct {
 	powerVSClientBuilder powervsclient.PowerVSClientBuilderFuncType
 	configManagedClient  runtimeclient.Client
 	powerVSMinimalClient powervsclient.MinimalPowerVSClientBuilderFuncType
+	dhcpIPCacheStore     cache.Store
 }
 
 // ActuatorParams holds parameter information for Actuator.
@@ -54,6 +56,7 @@ type ActuatorParams struct {
 	PowerVSClientBuilder powervsclient.PowerVSClientBuilderFuncType
 	ConfigManagedClient  runtimeclient.Client
 	PowerVSMinimalClient powervsclient.MinimalPowerVSClientBuilderFuncType
+	DHCPIPCacheStore     cache.Store
 }
 
 // NewActuator returns an actuator.
@@ -64,6 +67,7 @@ func NewActuator(params ActuatorParams) *Actuator {
 		powerVSClientBuilder: params.PowerVSClientBuilder,
 		configManagedClient:  params.ConfigManagedClient,
 		powerVSMinimalClient: params.PowerVSMinimalClient,
+		dhcpIPCacheStore:     params.DHCPIPCacheStore,
 	}
 }
 
@@ -87,6 +91,7 @@ func (a *Actuator) Create(ctx context.Context, machine *machinev1beta1.Machine) 
 		powerVSClientBuilder: a.powerVSClientBuilder,
 		configManagedClient:  a.configManagedClient,
 		powerVSMinimalClient: a.powerVSMinimalClient,
+		dhcpIPCacheStore:     a.dhcpIPCacheStore,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)
@@ -114,6 +119,7 @@ func (a *Actuator) Exists(ctx context.Context, machine *machinev1beta1.Machine) 
 		powerVSClientBuilder: a.powerVSClientBuilder,
 		configManagedClient:  a.configManagedClient,
 		powerVSMinimalClient: a.powerVSMinimalClient,
+		dhcpIPCacheStore:     a.dhcpIPCacheStore,
 	})
 	if err != nil {
 		return false, fmt.Errorf(scopeFailFmt, machine.GetName(), err)
@@ -131,6 +137,7 @@ func (a *Actuator) Update(ctx context.Context, machine *machinev1beta1.Machine) 
 		powerVSClientBuilder: a.powerVSClientBuilder,
 		configManagedClient:  a.configManagedClient,
 		powerVSMinimalClient: a.powerVSMinimalClient,
+		dhcpIPCacheStore:     a.dhcpIPCacheStore,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)
@@ -171,6 +178,7 @@ func (a *Actuator) Delete(ctx context.Context, machine *machinev1beta1.Machine) 
 		powerVSClientBuilder: a.powerVSClientBuilder,
 		configManagedClient:  a.configManagedClient,
 		powerVSMinimalClient: a.powerVSMinimalClient,
+		dhcpIPCacheStore:     a.dhcpIPCacheStore,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)

--- a/pkg/actuators/machine/actuator_test.go
+++ b/pkg/actuators/machine/actuator_test.go
@@ -6,15 +6,15 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/rand"
-
 	"github.com/golang/mock/gomock"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -216,6 +216,7 @@ func TestActuatorEvents(t *testing.T) {
 				EventRecorder:        eventRecorder,
 				PowerVSClientBuilder: powerVSClientBuilder,
 				PowerVSMinimalClient: minimalPowerVSClient,
+				DHCPIPCacheStore:     cache.NewTTLStore(CacheKeyFunc, CacheTTL),
 			}
 			actuator := NewActuator(params)
 			tc.operation(actuator, machine)
@@ -289,6 +290,7 @@ func TestActuatorExists(t *testing.T) {
 				EventRecorder:        eventRecorder,
 				PowerVSClientBuilder: powerVSClientBuilder,
 				PowerVSMinimalClient: minimalPowerVSClient,
+				DHCPIPCacheStore:     cache.NewTTLStore(CacheKeyFunc, CacheTTL),
 			}
 			actuator := NewActuator(params)
 

--- a/pkg/actuators/machine/caching.go
+++ b/pkg/actuators/machine/caching.go
@@ -1,0 +1,20 @@
+package machine
+
+import "time"
+
+// CacheTTL is duration of time to store the vm ip in cache
+// Currently the sync period for Power VS machine api controller is 10 minutes that means every 10 minutes
+// there will be a reconcilation on machine objects, So setting cache timeout to 20 minutes so the cache updates will happen
+// once in 2 reconcilations.
+const CacheTTL = time.Duration(20) * time.Minute
+
+// vmIP holds the vm name and corresponding dhcp ip used to cache the dhcp ip
+type vmIP struct {
+	name string
+	ip   string
+}
+
+// CacheKeyFunc defines the key function required in TTLStore.
+func CacheKeyFunc(obj interface{}) (string, error) {
+	return obj.(vmIP).name, nil
+}

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"k8s.io/utils/pointer"
+
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM/go-sdk-core/v5/core"
 
@@ -150,4 +152,39 @@ func stubGetNetworks(nameprefix string, count int) *models.Networks {
 			})
 	}
 	return images
+}
+
+func stubGetDHCPServers(serverID, networkID string) models.DHCPServers {
+	return models.DHCPServers{
+		&models.DHCPServer{
+			ID: pointer.StringPtr(serverID),
+			Network: &models.DHCPServerNetwork{
+				ID: pointer.StringPtr(networkID),
+			},
+		},
+	}
+}
+
+func stubGetDHCPServerByID(id, ip, mac string) *models.DHCPServerDetail {
+	return &models.DHCPServerDetail{
+		ID: pointer.StringPtr(id),
+		Leases: []*models.DHCPServerLeases{
+			{
+				InstanceIP:         pointer.StringPtr(ip),
+				InstanceMacAddress: pointer.StringPtr(mac),
+			},
+		},
+	}
+}
+
+func stubGetNetworkWithName(name, id string) *models.Networks {
+	networks := &models.Networks{
+		Networks: []*models.NetworkReference{
+			{
+				Name:      pointer.StringPtr(name),
+				NetworkID: pointer.StringPtr(id),
+			},
+		},
+	}
+	return networks
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -34,6 +34,8 @@ type Client interface {
 	GetNetworks() (*models.Networks, error)
 	GetCloudServiceInstances() ([]bluemixmodels.ServiceInstanceV2, error)
 	GetCloudServiceInstanceByName(name string) ([]bluemixmodels.ServiceInstanceV2, error)
+	GetDHCPServers() (models.DHCPServers, error)
+	GetDHCPServerByID(id string) (*models.DHCPServerDetail, error)
 
 	GetZone() string
 	GetRegion() string

--- a/pkg/client/mock/client_generated.go
+++ b/pkg/client/mock/client_generated.go
@@ -94,6 +94,36 @@ func (mr *MockClientMockRecorder) GetCloudServiceInstances() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudServiceInstances", reflect.TypeOf((*MockClient)(nil).GetCloudServiceInstances))
 }
 
+// GetDHCPServerByID mocks base method.
+func (m *MockClient) GetDHCPServerByID(id string) (*models0.DHCPServerDetail, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDHCPServerByID", id)
+	ret0, _ := ret[0].(*models0.DHCPServerDetail)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDHCPServerByID indicates an expected call of GetDHCPServerByID.
+func (mr *MockClientMockRecorder) GetDHCPServerByID(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDHCPServerByID", reflect.TypeOf((*MockClient)(nil).GetDHCPServerByID), id)
+}
+
+// GetDHCPServers mocks base method.
+func (m *MockClient) GetDHCPServers() (models0.DHCPServers, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDHCPServers")
+	ret0, _ := ret[0].(models0.DHCPServers)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDHCPServers indicates an expected call of GetDHCPServers.
+func (mr *MockClientMockRecorder) GetDHCPServers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDHCPServers", reflect.TypeOf((*MockClient)(nil).GetDHCPServers))
+}
+
 // GetImages mocks base method.
 func (m *MockClient) GetImages() (*models0.Images, error) {
 	m.ctrl.T.Helper()

--- a/pkg/client/powervs_client.go
+++ b/pkg/client/powervs_client.go
@@ -190,6 +190,7 @@ func NewValidatedClient(ctrlRuntimeClient client.Client, secretName, namespace, 
 	c.InstanceClient = instance.NewIBMPIInstanceClient(ctx, c.session, cloudInstanceID)
 	c.NetworkClient = instance.NewIBMPINetworkClient(ctx, c.session, cloudInstanceID)
 	c.ImageClient = instance.NewIBMPIImageClient(ctx, c.session, cloudInstanceID)
+	c.DHCPClient = instance.NewIBMPIDhcpClient(ctx, c.session, cloudInstanceID)
 	return c, err
 }
 
@@ -231,6 +232,7 @@ type powerVSClient struct {
 	InstanceClient *instance.IBMPIInstanceClient
 	NetworkClient  *instance.IBMPINetworkClient
 	ImageClient    *instance.IBMPIImageClient
+	DHCPClient     *instance.IBMPIDhcpClient
 }
 
 func (p *powerVSClient) GetImages() (*models.Images, error) {
@@ -302,6 +304,14 @@ func (p *powerVSClient) GetCloudServiceInstanceByName(name string) ([]bluemixmod
 		}
 	}
 	return instances, nil
+}
+
+func (p *powerVSClient) GetDHCPServers() (models.DHCPServers, error) {
+	return p.DHCPClient.GetAll()
+}
+
+func (p *powerVSClient) GetDHCPServerByID(id string) (*models.DHCPServerDetail, error) {
+	return p.DHCPClient.Get(id)
 }
 
 func (p *powerVSClient) GetZone() string {


### PR DESCRIPTION
Main intention of this PR is to set the NodeInternalIP for machine so that the cluster auto approver will approve the server csr requests

1. With DHCP server in place , The IP of the machine needs to fetched from dhcp server lease using the VM mac address
2. Also a cache implementation is added to avoid frequent calls to DHCP server


- [x] Add unit test cases