### PR TITLE
Add infrastructure sync controller for custom service endpoints

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -37,6 +37,7 @@ import (
 	machineactuator "github.com/openshift/machine-api-provider-powervs/pkg/actuators/machine"
 	machinesetcontroller "github.com/openshift/machine-api-provider-powervs/pkg/actuators/machineset"
 	powervsclient "github.com/openshift/machine-api-provider-powervs/pkg/client"
+	"github.com/openshift/machine-api-provider-powervs/pkg/controllers"
 	"github.com/openshift/machine-api-provider-powervs/pkg/options"
 	"github.com/openshift/machine-api-provider-powervs/pkg/version"
 )
@@ -175,6 +176,14 @@ func main() {
 		Log:    ctrl.Log.WithName("controllers").WithName("MachineSet"),
 	}).SetupWithManager(mgr, controller.Options{}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MachineSet")
+		os.Exit(1)
+	}
+
+	if err := (&controllers.Reconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("CustomServiceEndpoint"),
+	}).SetupWithManager(mgr, controller.Options{}); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "CustomServiceEndpoint")
 		os.Exit(1)
 	}
 

--- a/pkg/controllers/custom_service_endpoint_controller.go
+++ b/pkg/controllers/custom_service_endpoint_controller.go
@@ -1,0 +1,142 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"net/url"
+
+	"github.com/go-logr/logr"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+const infrastructureResourceName = "cluster"
+
+// Reconciler reconciles infrastructure object.
+type Reconciler struct {
+	Client client.Client
+	Log    logr.Logger
+
+	recorder record.EventRecorder
+	scheme   *runtime.Scheme
+}
+
+// SetupWithManager creates a new controller for a manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
+	_, err := ctrl.NewControllerManagedBy(mgr).
+		For(&configv1.Infrastructure{}).
+		WithOptions(options).
+		Build(r)
+
+	if err != nil {
+		return fmt.Errorf("failed setting up with a controller manager: %w", err)
+	}
+	r.recorder = mgr.GetEventRecorderFor("custom-service-endpoint-controller")
+	r.scheme = mgr.GetScheme()
+	return nil
+}
+
+// Reconcile implements controller runtime Reconciler interface.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := r.Log.WithValues("CustomServiceEndpoint", req.Name, "namespace", req.Namespace)
+	logger.V(3).Info("CustomServiceEndpoint Reconciling")
+
+	infra := &configv1.Infrastructure{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: infrastructureResourceName}, infra); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("infrastructure resource not found")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	currentInfra := infra.DeepCopy()
+	var services []configv1.PowerVSServiceEndpoint
+	if currentInfra.Spec.PlatformSpec.PowerVS != nil {
+		services = append(services, currentInfra.Spec.PlatformSpec.PowerVS.ServiceEndpoints...)
+	}
+
+	if len(services) == 0 {
+		logger.Info("no custom service endpoints are specified")
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("custom service endpoints in platformSpec", "endpoints", services)
+	if err := validateServiceEndpoints(services); err != nil {
+		r.recorder.Eventf(currentInfra, corev1.EventTypeWarning, "Invalid spec.platformSpec.powervs.serviceEndpoints provided for infrastructures.cluster", "%v", err)
+		return ctrl.Result{}, err
+	}
+	sort.Slice(services, func(i, j int) bool {
+		return services[i].Name < services[j].Name
+	})
+
+	var existingServices []configv1.PowerVSServiceEndpoint
+	if currentInfra.Status.PlatformStatus != nil && currentInfra.Status.PlatformStatus.PowerVS != nil {
+		existingServices = append(existingServices, currentInfra.Status.PlatformStatus.PowerVS.ServiceEndpoints...)
+	}
+	logger.Info("existing custom service endpoints in platformStatus", "endpoints", existingServices)
+	if equality.Semantic.DeepEqual(existingServices, services) {
+		return ctrl.Result{}, nil // nothing to do now
+	}
+
+	if currentInfra.Status.PlatformStatus == nil {
+		currentInfra.Status.PlatformStatus = &configv1.PlatformStatus{}
+	}
+	if currentInfra.Status.PlatformStatus.PowerVS == nil {
+		currentInfra.Status.PlatformStatus.PowerVS = &configv1.PowerVSPlatformStatus{}
+	}
+
+	currentInfra.Status.PlatformStatus.PowerVS.ServiceEndpoints = services
+	logger.Info("updating the platformStatus", "services", services)
+	err := r.Client.Status().Update(ctx, currentInfra)
+	return ctrl.Result{}, err
+}
+
+func validateServiceEndpoints(endpoints []configv1.PowerVSServiceEndpoint) error {
+	fldPath := field.NewPath("spec", "platformSpec", "powervs", "serviceEndpoints")
+
+	allErrs := field.ErrorList{}
+	tracker := map[string]int{}
+	for idx, e := range endpoints {
+		fldp := fldPath.Index(idx)
+		if eidx, ok := tracker[e.Name]; ok {
+			allErrs = append(allErrs, field.Invalid(fldp.Child("name"), e.Name, fmt.Sprintf("duplicate service endpoint not allowed for %s, service endpoint already defined at %s", e.Name, fldPath.Index(eidx))))
+		} else {
+			tracker[e.Name] = idx
+		}
+
+		if err := validateServiceURL(e.URL); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldp.Child("url"), e.URL, err.Error()))
+		}
+	}
+	return allErrs.ToAggregate()
+}
+
+func validateServiceURL(uri string) error {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return err
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("host cannot be empty, empty host provided")
+	}
+	if s := u.Scheme; s != "https" {
+		return fmt.Errorf("invalid scheme %s, only https allowed", s)
+	}
+	if r := u.RequestURI(); r != "/" {
+		return fmt.Errorf("no path or request parameters must be provided, %q was provided", r)
+	}
+
+	return nil
+}

--- a/pkg/controllers/custom_service_endpoint_controller_test.go
+++ b/pkg/controllers/custom_service_endpoint_controller_test.go
@@ -1,0 +1,308 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"log"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestResolveEndpoints(t *testing.T) {
+	var cfg *rest.Config
+	var k8sClient client.Client
+	var err error
+	ctx := context.Background()
+
+	g := NewWithT(t)
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "machine", "v1beta1"),
+			filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "config", "v1"),
+		},
+	}
+	configv1.AddToScheme(scheme.Scheme)
+
+	cfg, err = testEnv.Start()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cfg).ToNot(BeNil())
+
+	defer func() {
+		if err := testEnv.Stop(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cases := []struct {
+		name             string
+		obj              *configv1.Infrastructure
+		expectedInfraObj *configv1.Infrastructure
+		updateStatus     configv1.InfrastructureStatus
+		expectedErr      error
+	}{
+		{
+			name: "with no service endpoints",
+			obj: &configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+			},
+			expectedInfraObj: &configv1.Infrastructure{},
+		},
+		{
+			name:        "with invalid status in infrastructure object",
+			obj:         stubInfrastructure(),
+			expectedErr: errors.New("infrastructure.config.openshift.io \"cluster\" is invalid"),
+		},
+		{
+			name:        "with invalid Custom Service Endpoints",
+			obj:         stubInvalidCustomServiceEndpoints(),
+			expectedErr: errors.New("invalid value: \"https://dal.power-iaas.test.cloud.ibm.com/abc\": no path or request parameters must be provided, \"/abc\" was provided"),
+		},
+		{
+			name: "with valid custom service endpoints",
+			obj:  stubInfrastructure(),
+			updateStatus: configv1.InfrastructureStatus{
+				ControlPlaneTopology:   "HighlyAvailable",
+				InfrastructureTopology: "HighlyAvailable",
+			},
+			expectedInfraObj: expectedInfraObject(),
+		},
+		{
+			name: "with existing custom service endpoints in infrastructure object",
+			obj:  stubInfrastructure(),
+			updateStatus: configv1.InfrastructureStatus{
+				ControlPlaneTopology:   "HighlyAvailable",
+				InfrastructureTopology: "HighlyAvailable",
+				PlatformStatus: &configv1.PlatformStatus{
+					PowerVS: &configv1.PowerVSPlatformStatus{
+						ServiceEndpoints: []configv1.PowerVSServiceEndpoint{
+							{
+								Name: "iam",
+								URL:  "https://iam.test.cloud.ibm.com",
+							},
+							{
+								Name: "pe",
+								URL:  "https://dal.power-iaas.test.cloud.ibm.com",
+							},
+						},
+					},
+				},
+			},
+			expectedInfraObj: expectedInfraObject(),
+		},
+		{
+			name: "adding new endpoint to the existing custom service endpoints",
+			obj: &configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						Type: "PowerVS",
+						PowerVS: &configv1.PowerVSPlatformSpec{
+							ServiceEndpoints: []configv1.PowerVSServiceEndpoint{
+								{
+									Name: "iam",
+									URL:  "https://iam.test.cloud.ibm.com",
+								},
+								{
+									Name: "pe",
+									URL:  "https://dal.power-iaas.test.cloud.ibm.com",
+								},
+								{
+									Name: "rc",
+									URL:  "https://test.resource-controller.cloud.ibm.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			updateStatus: configv1.InfrastructureStatus{
+				ControlPlaneTopology:   "HighlyAvailable",
+				InfrastructureTopology: "HighlyAvailable",
+				PlatformStatus: &configv1.PlatformStatus{
+					PowerVS: &configv1.PowerVSPlatformStatus{
+						ServiceEndpoints: []configv1.PowerVSServiceEndpoint{
+							{
+								Name: "iam",
+								URL:  "https://iam.test.cloud.ibm.com",
+							},
+							{
+								Name: "pe",
+								URL:  "https://dal.power-iaas.test.cloud.ibm.com",
+							},
+						},
+					},
+				},
+			},
+			expectedInfraObj: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					ControlPlaneTopology:   "HighlyAvailable",
+					InfrastructureTopology: "HighlyAvailable",
+					PlatformStatus: &configv1.PlatformStatus{
+						PowerVS: &configv1.PowerVSPlatformStatus{
+							ServiceEndpoints: []configv1.PowerVSServiceEndpoint{
+								{
+									Name: "iam",
+									URL:  "https://iam.test.cloud.ibm.com",
+								},
+								{
+									Name: "pe",
+									URL:  "https://dal.power-iaas.test.cloud.ibm.com",
+								},
+								{
+									Name: "rc",
+									URL:  "https://test.resource-controller.cloud.ibm.com",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "removing existing custom service endpoints in infrastructure object",
+			obj:  stubInfrastructure(),
+			updateStatus: configv1.InfrastructureStatus{
+				ControlPlaneTopology:   "HighlyAvailable",
+				InfrastructureTopology: "HighlyAvailable",
+				PlatformStatus: &configv1.PlatformStatus{
+					PowerVS: &configv1.PowerVSPlatformStatus{
+						ServiceEndpoints: []configv1.PowerVSServiceEndpoint{
+							{
+								Name: "iam",
+								URL:  "https://iam.test.cloud.ibm.com",
+							},
+							{
+								Name: "pe",
+								URL:  "https://dal.power-iaas.test.cloud.ibm.com",
+							},
+							{
+								Name: "rc",
+								URL:  "https://test.resource-controller.cloud.ibm.com",
+							},
+						},
+					},
+				},
+			},
+			expectedInfraObj: expectedInfraObject(),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g.Expect(k8sClient.Create(ctx, tc.obj)).To(Succeed())
+			defer func() {
+				g.Expect(k8sClient.Delete(ctx, tc.obj)).To(Succeed())
+			}()
+
+			if tc.updateStatus.ControlPlaneTopology != "" {
+				infraObject := &configv1.Infrastructure{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: infrastructureResourceName}, infraObject)).To(Succeed())
+				infraObject.Status = tc.updateStatus
+				g.Expect(k8sClient.Status().Update(ctx, infraObject)).To(Succeed())
+			}
+
+			r := Reconciler{
+				Client:   k8sClient,
+				recorder: &record.FakeRecorder{},
+				Log:      ctrl.Log.WithName("controllers").WithName("CustomServiceEndpoint"),
+			}
+			_, err := r.Reconcile(context.Background(), ctrl.Request{})
+			if tc.expectedErr != nil {
+				g.Expect(strings.ToLower(err.Error())).To(ContainSubstring(tc.expectedErr.Error()))
+			} else {
+				infraObject := &configv1.Infrastructure{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: infrastructureResourceName}, infraObject)).To(Succeed())
+				g.Expect(infraObject.Status).To(Equal(tc.expectedInfraObj.Status))
+			}
+		})
+	}
+}
+
+func stubInfrastructure() *configv1.Infrastructure {
+	return &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.InfrastructureSpec{
+			PlatformSpec: configv1.PlatformSpec{
+				Type: "PowerVS",
+				PowerVS: &configv1.PowerVSPlatformSpec{
+					ServiceEndpoints: []configv1.PowerVSServiceEndpoint{
+						{
+							Name: "iam",
+							URL:  "https://iam.test.cloud.ibm.com",
+						},
+						{
+							Name: "pe",
+							URL:  "https://dal.power-iaas.test.cloud.ibm.com",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func stubInvalidCustomServiceEndpoints() *configv1.Infrastructure {
+	return &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.InfrastructureSpec{
+			PlatformSpec: configv1.PlatformSpec{
+				Type: "PowerVS",
+				PowerVS: &configv1.PowerVSPlatformSpec{
+					ServiceEndpoints: []configv1.PowerVSServiceEndpoint{
+						{
+							Name: "pe",
+							URL:  "https://dal.power-iaas.test.cloud.ibm.com/abc",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func expectedInfraObject() *configv1.Infrastructure {
+	return &configv1.Infrastructure{
+		Status: configv1.InfrastructureStatus{
+			ControlPlaneTopology:   "HighlyAvailable",
+			InfrastructureTopology: "HighlyAvailable",
+			PlatformStatus: &configv1.PlatformStatus{
+				PowerVS: &configv1.PowerVSPlatformStatus{
+					ServiceEndpoints: []configv1.PowerVSServiceEndpoint{
+						{
+							Name: "iam",
+							URL:  "https://iam.test.cloud.ibm.com",
+						},
+						{
+							Name: "pe",
+							URL:  "https://dal.power-iaas.test.cloud.ibm.com",
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Controller to sync the custom service endpoints from spec field of infrastructure object to status field.

- [x] Add Unit Testcases
- [x] Basic integration testing on real IPI Power VS Cluster

openshift/api PR to add ServiceEndpoints: https://github.com/openshift/api/pull/1025
Its originally started from https://github.com/openshift/cluster-config-operator/pull/256