### PR TITLE
MULTIARCH-3669:  Set instance build condition to avoid attempting to create duplicate vm with same name

### DIFF
--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -207,7 +207,6 @@ func (r *Reconciler) exists() (bool, error) {
 			klog.Infof("%s: Possible eventual-consistency discrepancy; returning an error to requeue", r.machine.Name)
 			return false, &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
 		}
-
 		klog.Infof("%s: Instance does not exist", r.machine.Name)
 		return false, nil
 	}
@@ -314,6 +313,7 @@ func (r *Reconciler) requeueIfInstanceBuilding(instance *models.PVMInstance) err
 	// we get a public IP populated more quickly.
 	if instance.Status != nil && *instance.Status == client.InstanceStateNameBuild {
 		klog.Infof("%s: Instance state still building, returning an error to requeue", r.machine.Name)
+		r.machineScope.setProviderStatus(instance, conditionBuild())
 		return &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
 	}
 

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -55,7 +55,7 @@ func stubPowerVSCredentialsSecret(name string) *corev1.Secret {
 			Namespace: defaultNamespace,
 		},
 		Data: map[string][]byte{
-			"ibmcloud_api_key": []byte("Kl9k1elFgPb_QgEDF0d5iNHMOFa--YX6JWLpi0XkWn"),
+			"ibmcloud_api_key": []byte("api_key"),
 		},
 	}
 }
@@ -123,6 +123,14 @@ func stubGetInstance() *models.PVMInstance {
 	return &models.PVMInstance{
 		PvmInstanceID: &dummyInstanceID,
 		Status:        &status,
+		ServerName:    core.StringPtr("instance"),
+	}
+}
+
+func stubInstanceWithBuildState() *models.PVMInstance {
+	return &models.PVMInstance{
+		PvmInstanceID: pointer.String("instance-id"),
+		Status:        pointer.String("BUILD"),
 		ServerName:    core.StringPtr("instance"),
 	}
 }

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -27,6 +27,7 @@ import (
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
+	"github.com/openshift/machine-api-provider-powervs/pkg/client"
 )
 
 const (
@@ -93,6 +94,15 @@ func conditionFailed() metav1.Condition {
 		Type:   string(machinev1beta1.MachineCreation),
 		Status: metav1.ConditionFalse,
 		Reason: machinev1beta1.MachineCreationFailedConditionReason,
+	}
+}
+
+func conditionBuild() metav1.Condition {
+	return metav1.Condition{
+		Type:    string(machinev1beta1.MachineCreation),
+		Status:  client.InstanceStateNameBuild,
+		Reason:  client.InstanceBuildReason,
+		Message: "Machine is in build state",
 	}
 }
 

--- a/pkg/client/powervs_client.go
+++ b/pkg/client/powervs_client.go
@@ -51,6 +51,8 @@ const (
 	InstanceStateNameActive = "ACTIVE"
 	//InstanceStateNameBuild is indicates the build state of Power VS instance
 	InstanceStateNameBuild = "BUILD"
+	//InstanceBuildReason indicates that instance is in building state
+	InstanceBuildReason = "InstanceBuildState"
 
 	// globalInfrastuctureName default name for infrastructure object
 	globalInfrastuctureName = "cluster"


### PR DESCRIPTION
It will take few seconds for the newly created vm to be available in getAllInstaces() but we can fetch the vm directly if we know the instance id.

As a part of this PR we are setting that vm is in build condition and as a part of it [instance id will be set in provider status](https://github.com/Karthik-K-N/machine-api-provider-powervs/blob/da14713a9e2c5b27bb00383a4f5d08b15908bc58/pkg/actuators/machine/machine_scope.go#L169-L175).
Later it will help in exists() method to[ fetch the vm by instance id](https://github.com/Karthik-K-N/machine-api-provider-powervs/blob/473070f9045e7a6e83167076680067beb2b169f0/pkg/actuators/machine/reconciler.go#L326-L334).