### PR TITLE
OCPBUGS-33995: Add more custom endpoints

### DIFF
--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -165,13 +165,14 @@ func ProviderSpecFromRawExtension(rawExtension *runtime.RawExtension) (*machinev
 	if rawExtension == nil {
 		return &machinev1.PowerVSMachineProviderConfig{}, nil
 	}
+	klog.V(3).Infof("ProviderSpecFromRawExtension: rawExtension = %+v", string(rawExtension.Raw))
 
 	spec := new(machinev1.PowerVSMachineProviderConfig)
 	if err := json.Unmarshal(rawExtension.Raw, &spec); err != nil {
 		return nil, fmt.Errorf("error unmarshalling providerSpec: %v", err)
 	}
 
-	klog.V(5).Infof("Got provider Spec from raw extension: %+v", spec)
+	klog.V(3).Infof("Got provider Spec from raw extension: %+v", spec)
 	return spec, nil
 }
 
@@ -180,12 +181,13 @@ func ProviderStatusFromRawExtension(rawExtension *runtime.RawExtension) (*machin
 	if rawExtension == nil {
 		return &machinev1.PowerVSMachineProviderStatus{}, nil
 	}
+	klog.V(3).Infof("ProviderStatusFromRawExtension: rawExtension = %+v", string(rawExtension.Raw))
 
 	providerStatus := new(machinev1.PowerVSMachineProviderStatus)
 	if err := json.Unmarshal(rawExtension.Raw, providerStatus); err != nil {
 		return nil, fmt.Errorf("error unmarshalling providerStatus: %v", err)
 	}
 
-	klog.V(5).Infof("Got provider Status from raw extension: %+v", providerStatus)
+	klog.V(3).Infof("Got provider Status from raw extension: %+v", providerStatus)
 	return providerStatus, nil
 }

--- a/pkg/client/powervs_client.go
+++ b/pkg/client/powervs_client.go
@@ -526,8 +526,11 @@ func resolveEndpoints(ctrlRuntimeClient client.Client) (map[string]string, error
 }
 
 func setCustomEndpoints(customEndpointsMap map[string]string, keys []string) error {
-	//TODO(Doubt): Is it required to validate the endpoints again before setting it or blindly trust installer
 	for _, key := range keys {
+		if _, ok := endPointKeyToEnvNameMap[key]; !ok {
+			klog.Infof("setCustomEndpoints ignoring %s", key)
+			continue
+		}
 		if val, ok := customEndpointsMap[key]; ok {
 			if err := setEnvironmentVariables(endPointKeyToEnvNameMap[key], val); err != nil {
 				return err


### PR DESCRIPTION
When you pass in endpoints in install config:
```
    serviceEndpoints:
    - name: dnsservices
      url: https://api.dns-svcs.cloud.ibm.com
    - name: cos
      url: https://s3.us-south.cloud-object-storage.appdomain.cloud
```

You see the following error:
```
failed creating minimalPowerVS client Error: setenv: invalid argument
```

Add some more endpoint mapping.  Also, return an error if an endpoint is not known.