### PR TITLE
MULTIARCH-5163: Update powervs-utils regions to include us-south and tor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/openshift/api v0.0.0-20240904015708-69df64132c91
 	github.com/openshift/machine-api-operator v0.2.1-0.20240912100427-050b12eb6e05
 	github.com/pkg/errors v0.9.1
-	github.com/ppc64le-cloud/powervs-utils v0.0.0-20240105123432-7588e9595c17
+	github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247
 
 	// kube 1.30
 	k8s.io/api v0.30.1

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/ppc64le-cloud/powervs-utils v0.0.0-20240105123432-7588e9595c17 h1:4Hd7ppyxQE648qShgm62PNXehIOMSOZR0V9zySJEgzE=
 github.com/ppc64le-cloud/powervs-utils v0.0.0-20240105123432-7588e9595c17/go.mod h1:KImYgHmvBVtAczNhyDBDSN54PGIdz0+QiPVQMmObEQY=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247 h1:XY7lIZaLKFDyETNfTTiYmaXO+mk9apox4otFel88nUk=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247/go.mod h1:yfr6HHPYyJzVgnivMsobLMbHQqUHrzcIqWM4Nav4kc8=
 github.com/prometheus/client_golang v1.18.0 h1:HzFfmkOzH5Q8L8G+kSJKUx5dtG87sewO+FoDDqP5Tbk=
 github.com/prometheus/client_golang v1.18.0/go.mod h1:T+GXkCk5wSJyOqMIzVgvvjFDlkOQntgjkJWKrN5txjA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/vendor/github.com/ppc64le-cloud/powervs-utils/region.go
+++ b/vendor/github.com/ppc64le-cloud/powervs-utils/region.go
@@ -34,6 +34,8 @@ func GetRegion(zone string) (region string, err error) {
 		region = "mad"
 	case strings.HasPrefix(zone, "wdc"):
 		region = "wdc"
+	case strings.HasPrefix(zone, "tor"):
+		region = "tor"
 	default:
 		return "", fmt.Errorf("region not found for the zone, talk to the developer to add the support into the tool: %s", zone)
 	}
@@ -46,6 +48,8 @@ type Region struct {
 	VPCRegion   string
 	COSRegion   string
 	Zones       []string
+	SysTypes    []string
+	VPCZones    []string
 }
 
 // Regions provides a mapping between Power VS and IBM Cloud VPC and IBM COS regions.
@@ -54,7 +58,12 @@ var Regions = map[string]Region{
 		Description: "Dallas, USA",
 		VPCRegion:   "us-south",
 		COSRegion:   "us-south",
-		Zones:       []string{"dal12"},
+		Zones: []string{
+			"dal10",
+			"dal12",
+		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
 	},
 	"eu-de": {
 		Description: "Frankfurt, Germany",
@@ -64,6 +73,8 @@ var Regions = map[string]Region{
 			"eu-de-1",
 			"eu-de-2",
 		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"eu-de-1", "eu-de-2", "eu-de-3"},
 	},
 	"lon": {
 		Description: "London, UK.",
@@ -73,27 +84,46 @@ var Regions = map[string]Region{
 			"lon04",
 			"lon06",
 		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"eu-gb-1", "eu-gb-2", "eu-gb-3"},
 	},
 	"mad": {
 		Description: "Madrid, Spain",
 		VPCRegion:   "eu-es",
-		COSRegion:   "eu-es",
+		COSRegion:   "eu-de", // @HACK - PowerVS says COS not supported in this region
 		Zones: []string{
 			"mad02",
 			"mad04",
 		},
+		SysTypes: []string{"s1022"},
+		VPCZones: []string{"eu-es-1", "eu-es-2", "eu-es-3"},
 	},
 	"mon": {
 		Description: "Montreal, Canada",
-		VPCRegion:   "ca-tor",
+		VPCRegion:   "",
 		COSRegion:   "ca-tor",
 		Zones:       []string{"mon01"},
+		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{},
 	},
 	"osa": {
 		Description: "Osaka, Japan",
 		VPCRegion:   "jp-osa",
 		COSRegion:   "jp-osa",
 		Zones:       []string{"osa21"},
+		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"jp-osa-1", "jp-osa-2", "jp-osa-3"},
+	},
+	"sao": {
+		Description: "São Paulo, Brazil",
+		VPCRegion:   "br-sao",
+		COSRegion:   "br-sao",
+		Zones: []string{
+			"sao01",
+			"sao04",
+		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"br-sao-1", "br-sao-2", "br-sao-3"},
 	},
 	"syd": {
 		Description: "Sydney, Australia",
@@ -103,27 +133,42 @@ var Regions = map[string]Region{
 			"syd04",
 			"syd05",
 		},
-	},
-	"sao": {
-		Description: "São Paulo, Brazil",
-		VPCRegion:   "br-sao",
-		COSRegion:   "br-sao",
-		Zones:       []string{
-			"sao01",
-			"sao04",
-		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"au-syd-1", "au-syd-2", "au-syd-3"},
 	},
 	"tok": {
 		Description: "Tokyo, Japan",
 		VPCRegion:   "jp-tok",
 		COSRegion:   "jp-tok",
 		Zones:       []string{"tok04"},
+		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"jp-tok-1", "jp-tok-2", "jp-tok-3"},
 	},
+	"tor": {
+		Description: "Toronto, Canada",
+		VPCRegion:   "ca-tor",
+		COSRegion:   "ca-tor",
+		Zones:       []string{"tor01"},
+		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"ca-tor-1", "ca-tor-2", "ca-tor-3"},
+	}, // Keeping us-east and us-south zones as individual entries to easily map the respective VPC and COS regions by matching the prefix of the zone like in GetRegion()
 	"us-east": {
 		Description: "Washington DC, USA",
 		VPCRegion:   "us-east",
 		COSRegion:   "us-east",
 		Zones:       []string{"us-east"},
+		SysTypes:    []string{"s922", "e980"},
+		VPCZones:    []string{"us-east-1", "us-east-2", "us-east-3"},
+	},
+	"us-south": {
+		Description: "Dallas, USA",
+		VPCRegion:   "us-south",
+		COSRegion:   "us-south",
+		Zones: []string{
+			"us-south",
+		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"us-south-1", "us-south-2", "us-south-3"},
 	},
 	"wdc": {
 		Description: "Washington DC, USA",
@@ -133,7 +178,20 @@ var Regions = map[string]Region{
 			"wdc06",
 			"wdc07",
 		},
+		SysTypes: []string{"s922", "e980"},
+		VPCZones: []string{"us-east-1", "us-east-2", "us-east-3"},
 	},
+}
+
+// COSRegionForVPCRegion returns the corresponding COS region for the given VPC region
+func COSRegionForVPCRegion(vpcRegion string) (string, error) {
+	for r := range Regions {
+		if vpcRegion == Regions[r].VPCRegion {
+			return Regions[r].COSRegion, nil
+		}
+	}
+
+	return "", fmt.Errorf("COS region corresponding to a VPC region %s not found ", vpcRegion)
 }
 
 // VPCRegionForPowerVSRegion returns the VPC region for the specified PowerVS region.
@@ -181,4 +239,66 @@ func RegionShortNames() []string {
 		keys = append(keys, r)
 	}
 	return keys
+}
+
+// ValidateZone validates that the given zone is known/tested.
+func ValidateZone(zone string) bool {
+	for r := range Regions {
+		for z := range Regions[r].Zones {
+			if zone == Regions[r].Zones[z] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ZoneNames returns the list of zone names.
+func ZoneNames() []string {
+	zones := []string{}
+	for r := range Regions {
+		for z := range Regions[r].Zones {
+			zones = append(zones, Regions[r].Zones[z])
+		}
+	}
+	return zones
+}
+
+// RegionFromZone returns the region name for a given zone name.
+func RegionFromZone(zone string) string {
+	for r := range Regions {
+		for z := range Regions[r].Zones {
+			if zone == Regions[r].Zones[z] {
+				return r
+			}
+		}
+	}
+	return ""
+}
+
+// AvailableSysTypes returns the default system type for the zone.
+func AvailableSysTypes(region string) ([]string, error) {
+	knownRegion, ok := Regions[region]
+	if !ok {
+		return nil, fmt.Errorf("unknown region name provided")
+	}
+	return knownRegion.SysTypes, nil
+}
+
+// IsGlobalRoutingRequiredForTG returns true when powervs and vpc regions are different.
+func IsGlobalRoutingRequiredForTG(powerVSRegion string, vpcRegion string) bool {
+	if r, ok := Regions[powerVSRegion]; ok && r.VPCRegion == vpcRegion {
+		return false
+	}
+	return true
+}
+
+// VPCZonesForVPCRegion returns the VPC zones associated with the VPC region.
+func VPCZonesForVPCRegion(region string) ([]string, error) {
+	for _, regionDetails := range Regions {
+		if regionDetails.VPCRegion == region {
+			return regionDetails.VPCZones, nil
+		}
+	}
+	return nil, fmt.Errorf("VPC zones corresponding to the VPC region %s is not found", region)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -406,8 +406,8 @@ github.com/peterbourgon/diskv
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors
-# github.com/ppc64le-cloud/powervs-utils v0.0.0-20240105123432-7588e9595c17
-## explicit; go 1.15
+# github.com/ppc64le-cloud/powervs-utils v0.0.0-20240610070307-1c0d75a5c247
+## explicit; go 1.21
 github.com/ppc64le-cloud/powervs-utils
 # github.com/prometheus/client_golang v1.18.0
 ## explicit; go 1.19


### PR DESCRIPTION
powervs-utils now supports two new zones. Update the version of powervs-utils used to include these.