### PR TITLE
OCPBUGS-47476: Overrides URL for ResourceController client if provided

### DIFF
--- a/pkg/client/powervs_client.go
+++ b/pkg/client/powervs_client.go
@@ -51,6 +51,9 @@ const (
 	// customIamEndpointName is the key to fetch IAM endpoint override
 	customIamEndpointName = "IAM"
 
+	// customIamEndpointName is the key to fetch Resource Controller endpoint override
+	customRcEndpointName = "ResourceController"
+
 	// powerIaaSCustomEndpointName is the short name used to fetch Power IaaS endpoint URL
 	powerIaaSCustomEndpointName = "Power"
 
@@ -243,9 +246,13 @@ func NewMinimalPowerVSClient(ctrlRuntimeClient client.Client) (Client, error) {
 	if endpoints[customIamEndpointName] != "" {
 		authenticator.URL = endpoints[customIamEndpointName]
 	}
-	rcv2, err := resourcecontrollerv2.NewResourceControllerV2(&resourcecontrollerv2.ResourceControllerV2Options{
+	rcOptions := &resourcecontrollerv2.ResourceControllerV2Options{
 		Authenticator: authenticator,
-	})
+	}
+	if endpoints[customRcEndpointName] != "" {
+		rcOptions.URL = endpoints[customRcEndpointName]
+	}
+	rcv2, err := resourcecontrollerv2.NewResourceControllerV2(rcOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Like #95, this one is to properly use override URL for `ResourceController`, if provided. With this running locally, it is verified that the cluster would be able to provision worker VMs.