### PR TITLE
NO-ISSUE: Use OS_GIT_VERSION in Makefile when found (for Konflux builds)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifeq ($(DBG),1)
 GOGCFLAGS ?= -gcflags=all="-N -l"
 endif
 
-VERSION     ?= $(shell git describe --always --abbrev=7)
+VERSION     ?= $(if $(OS_GIT_VERSION),$(OS_GIT_VERSION),$(shell git describe --always --abbrev=7))
 REPO_PATH   ?= github.com/openshift/machine-api-provider-powervs
 LD_FLAGS    ?= -X $(REPO_PATH)/pkg/version.Raw=$(VERSION) -extldflags "-static"
 MUTABLE_TAG ?= latest


### PR DESCRIPTION
This change is motivated by the [slack discussion](https://redhat-internal.slack.com/archives/CB95J6R4N/p1749170294911329) in which it appears that Konflux system might need to recover the git version in a different way than what we traditionally used. 
This change might help with 4.20 images being wrongly labeled as explained in the thread